### PR TITLE
Fixed EventDateComparator

### DIFF
--- a/Uni_life_tracker/app/src/main/java/com/generic/plannr/UseCases/EventDateComparator.java
+++ b/Uni_life_tracker/app/src/main/java/com/generic/plannr/UseCases/EventDateComparator.java
@@ -14,10 +14,10 @@ public class EventDateComparator implements Comparator<Event> {
      * Compares two events by their date.
      * @param e1 represents an Event
      * @param e2 represents an other Event
-     * @return -1 if e1 occurs after e2, 0 if e1 and e2 occur at the same date-time,
-     * and 1 if e1 before e2.
+     * @return -1 if e1 before after e2, 0 if e1 and e2 occur at the same date-time,
+     * and 1 if e1 after e2.
      */
     public int compare(@NonNull Event e1, @NonNull Event e2) {
-        return e1.getStartDate().compareTo(e2.getStartDate());
+        return Integer.compare(e1.getStartDate().compareTo(e2.getStartDate()), 0);
     }
 }


### PR DESCRIPTION
fix: EventDateComparator was not working for events a day or more apart

Issue #68 
EventDateComparator uses LocalDateTime.compareTo which doesn't return -1, 1, 0
but instead returns the negative or positive value of the number of days the two events
are apart. This caused testing and sorting to be off. Now it returns -1, 1, or 0
for our purposes.

Fixed the javadoc as well to reflect the fix.